### PR TITLE
Only show socials if provided in `_config.yml`

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,24 +57,48 @@ layout: default
                 <section>
                     <h2>Follow me on ...</h2>
                     <ul class="icons">
-                        <li><a href="{{ site.social_urls.facebook }}" class="icon fa-facebook"><span
-                                class="label">Facebook</span></a>
-                        </li>
-                        <li><a href="{{ site.social_urls.twitter }}" class="icon fa-twitter"><span
-                                class="label">Twitter</span></a>
-                        </li>
-                        <li><a href="{{ site.social_urls.instagram }}" class="icon fa-instagram"><span
-                                class="label">Instagram</span></a>
-                        </li>
-                        <li><a href="{{ site.social_urls.dribbble }}" class="icon fa-dribbble"><span
-                                class="label">Dribbble</span></a>
-                        </li>
-                        <li><a href="{{ site.social_urls.github }}" class="icon fa-github"><span
-                                class="label">GitHub</span></a>
-                        </li>
-                        <li><a href="{{ site.social_urls.linkedin }}" class="icon fa-linkedin"><span
-                                class="label">LinkedIn</span></a>
-                        </li>
+                        {% if site.social_urls.facebook %}
+                            <li>
+                                <a href="{{ site.social_urls.facebook }}" class="icon fa-facebook">
+                                    <span class="label">Facebook</span>
+                                </a>
+                            </li>
+                        {% endif %}
+                        {% if site.social_urls.twitter %}
+                            <li>
+                                <a href="{{ site.social_urls.twitter }}" class="icon fa-twitter">
+                                    <span class="label">Twitter</span>
+                                </a>
+                            </li>
+                        {% endif %}
+                        {% if site.social_urls.instagram %}
+                            <li>
+                                <a href="{{ site.social_urls.instagram }}" class="icon fa-instagram">
+                                    <span class="label">Instagram</span>
+                                </a>
+                            </li>
+                        {% endif %}
+                        {% if site.social_urls.dribbble %}
+                            <li>
+                                <a href="{{ site.social_urls.dribbble }}" class="icon fa-dribbble">
+                                    <span class="label">Dribbble</span>
+                                </a>
+                            </li>
+                        {% endif %}
+                        {% if site.social_urls.github %}
+                            <li>
+                                <a href="{{ site.social_urls.github }}" class="icon fa-github">
+                                    <span class="label">GitHub</span>
+                                </a>
+                            </li>
+                        {% endif %}
+                        {% if site.social_urls.linkedin %}
+                            <li>
+                                <a href="{{ site.social_urls.linkedin }}" class="icon fa-linkedin">
+                                    <span class="label">LinkedIn</span>
+                                </a>
+                            </li>
+                        {% endif %}
                     </ul>
                 </section>
                 <p class="copyright">


### PR DESCRIPTION
I only wanted to use some of the social icons in the about section. So I removed some in the `social_urls` sections in `_config.yml`. But the icons were still showing after rebuilding.

So I've added a small if statement to each icon. This way it is possible to only use a subset of the social icons.