### PR TITLE
Fix a gulpfile bug on the sequence of resize's tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,7 +50,7 @@ gulp.task('minify-js', function () {
 gulp.task('build', gulp.series('sass', 'minify-js'));
 
 // resize images
-gulp.task('resize', gulp.series('delete', 'resize-images'));
+gulp.task('resize', gulp.series('resize-images', 'delete'));
 
 // default task
 gulp.task('default', gulp.series('build', 'resize'));


### PR DESCRIPTION
Hi,
The `resize` task should first `resize-images`, then `delete`. Otherwise, all images under `images/` would be deleted and none would be resized.