### PR TITLE
Support Google Analytics GA4

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,7 +9,7 @@
 <!--[if lte IE 8]>
 <link rel="stylesheet" href="assets/css/ie8.css"/><![endif]-->
 {% if site.google_analytics %}
-<!-- Google tag (gtag.js) -->
+<!-- Google Analytics (GA4) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,14 +8,13 @@
 <link rel="stylesheet" href="assets/css/ie9.css"/><![endif]-->
 <!--[if lte IE 8]>
 <link rel="stylesheet" href="assets/css/ie8.css"/><![endif]-->
-<!-- Google Analytics -->
 {% if site.google_analytics %}
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
 <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', '{{ site.google_analytics }}', 'auto');
-    ga('send', 'pageview');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ site.google_analytics }}');
 </script>
 {% endif %}


### PR DESCRIPTION
Google has moved away from analytics.js to using gtag.js:
https://developers.google.com/analytics/devguides/migration/ua/analyticsjs-to-gtagjs