### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ and thumbnail generation__. So if you're lazy like me then you can just do the f
 2. Go inside the project `$ cd photography`
 3. Install all dependencies by `$ npm install`
 4. Copy all your pictures (possibly jpg, the largest size available, straight from your camera) and put it inside `images` directory
-5. Run `$ gulp resize` to resize the images and to generate thumbnails automatically
-6. Push your changes to github.com by `$ git add --all` and `$ git commit -m "a nice commit message"` and then finally `$ git push origin master`
+5. Install imagemagick for resizing the images `$ brew install imagemagick` or `sudo apt-get install imagemagick`
+6. Run `$ gulp resize` to resize the images and to generate thumbnails automatically
+7. Push your changes to github.com by `$ git add --all` and `$ git commit -m "a nice commit message"` and then finally `$ git push origin master`
 
 ### Contact Form
 You can make the contact form work without the need of any server-side code. Just follow this [article on github](https://github.com/dwyl/html-form-send-email-via-google-script-without-server) which uses a simple google script to send emails or to upload to a google spreadsheet when someone submits the form.


### PR DESCRIPTION
Add additional instruction to install imagemagick before trying to resize the image prevents the error below.

[12:55:15] Using gulpfile ~/wudan/photography/gulpfile.js [12:55:15] Starting 'resize'...
[12:55:15] Starting 'resize-images'...
[12:55:16] 'resize-images' errored after 22 ms
[12:55:16] Error in plugin "gulp-gm"
Message:
    Error: Could not execute GraphicsMagick/ImageMagick: identify "-ping" "-format" "%wx%h" "-" this most likely means the gm/convert binaries can't be found
Details:
    domainEmitter: [object Object]
    domainThrown: false

[12:55:16] 'resize' errored after 24 ms